### PR TITLE
Fix icon hover colors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,10 +10,30 @@ export const metadata: Metadata = {
 
 export default function Home() {
   const profiles = [
-    { label: 'GitHub', url: 'https://github.com/cristiandouce', Icon: SiGithub, colorClass: 'text-gray-900' },
-    { label: 'LinkedIn', url: 'https://linkedin.com/in/cristiandouce', Icon: SiLinkedin, colorClass: 'text-blue-600' },
-    { label: 'npm', url: 'https://npmjs.com/~cristiandouce', Icon: SiNpm, colorClass: 'text-red-600' },
-    { label: 'X', url: 'https://x.com/cristiandouce', Icon: SiX, colorClass: 'text-black' },
+    {
+      label: 'GitHub',
+      url: 'https://github.com/cristiandouce',
+      Icon: SiGithub,
+      hoverClass: 'group-hover:text-gray-900',
+    },
+    {
+      label: 'LinkedIn',
+      url: 'https://linkedin.com/in/cristiandouce',
+      Icon: SiLinkedin,
+      hoverClass: 'group-hover:text-blue-600',
+    },
+    {
+      label: 'npm',
+      url: 'https://npmjs.com/~cristiandouce',
+      Icon: SiNpm,
+      hoverClass: 'group-hover:text-red-600',
+    },
+    {
+      label: 'X',
+      url: 'https://x.com/cristiandouce',
+      Icon: SiX,
+      hoverClass: 'group-hover:text-black',
+    },
   ];
 
   return (
@@ -32,7 +52,7 @@ export default function Home() {
 
       <nav className="mt-8 w-full max-w-md">
         <ul className="flex flex-row justify-start text-left md:justify-between md:text-center gap-6 ps-6 md:p-0 flex-wrap">
-          {profiles.map(({ label, url, Icon, colorClass }) => (
+          {profiles.map(({ label, url, Icon, hoverClass }) => (
             <li key={url} className="group grow flex-1 md:flex-auto min-w-1/3 md:min-w-auto">
               <Link
                 href={url}
@@ -41,7 +61,7 @@ export default function Home() {
                 className="flex items-center gap-2 text-gray-700 transition-colors duration-150 text-base sm:text-lg"
               >
                 <Icon
-                  className={`w-6 h-6 text-gray-500 transition-colors duration-150 group-hover:${colorClass}`}
+                  className={`w-6 h-6 text-gray-500 transition-colors duration-150 ${hoverClass}`}
                   aria-hidden="true"
                 />
                 <span>{label}</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 text-gray-700 transition-colors duration-150 text-base sm:text-lg"
+                className="flex items-center gap-2 text-gray-700 transition-colors duration-150 text-base sm:text-lg group-hover:text-black"
               >
                 <Icon
                   className={`w-6 h-6 text-gray-500 transition-colors duration-150 ${hoverClass}`}


### PR DESCRIPTION
## Summary
- make link icons use explicit group-hover colors so they change from gray on hover

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855be2346088328af6c55100b517a67